### PR TITLE
Sorting CSN read results, so contract entities will be sorted

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -18,7 +18,8 @@
                 "I",
                 "--format",
                 "--json",
-                "--debug"
+                "--debug",
+                "--sort"
             ],
             "runtimeArgs": ["-r", "ts-node/register"],
             "cwd": "${workspaceRoot}",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -29,6 +29,10 @@ function main(): void {
             "-f, --format",
             "Flag, whether to format the outputted source code or not (will try to format with prettier rules in the project)"
         )
+        .option(
+            "-s, --sort",
+            "Flag, whether to sort outputted source code or not"
+        )
         .parse(process.argv);
 
     if (!process.argv.slice(2).length) {

--- a/src/program.ts
+++ b/src/program.ts
@@ -101,12 +101,12 @@ export class Program {
     ): Promise<unknown> {
         const csn = await cds.load(path);
 
-        let result: ICsn = JSON.parse(cds.compile.to.json(csn));
+        const result: ICsn = JSON.parse(cds.compile.to.json(csn));
 
         if (sort) {
             result.definitions = Object.fromEntries(
-                Object.entries(result.definitions).sort((a, b) =>
-                    String(a[0]).localeCompare(b[0])
+                Object.entries(result.definitions).sort((key, value) =>
+                    String(key[0]).localeCompare(value[0])
                 )
             );
         }

--- a/src/program.ts
+++ b/src/program.ts
@@ -27,12 +27,23 @@ export class Program {
      */
     public async run(options: IOptions): Promise<void> {
         // Load compiled CDS.
-        const jsonObj = await this.loadCdsAndConvertToJSON(options.cds);
+        const jsonObj = await this.loadCdsAndConvertToJSON(
+            options.cds,
+            options.sort
+        );
 
         // Write the compiled CDS JSON to disc for debugging.
         if (options.json) {
             fs.writeFileSync(options.output + ".json", JSON.stringify(jsonObj));
         }
+
+        // if (options.sort && typeof jsonObj === "unknow") {
+        //     jsonObj.definitions = Object.fromEntries(
+        //         Object.entries(jsonObj.definitions).sort((a, b) =>
+        //             String(a[0]).localeCompare(b[0])
+        //         )
+        //     );
+        // }
 
         // Parse compile CDS.
         const parsed = new CDSParser().parse(jsonObj as ICsn);
@@ -84,9 +95,23 @@ export class Program {
      * @returns {Promise<any>}
      * @memberof Program
      */
-    private async loadCdsAndConvertToJSON(path: string): Promise<unknown> {
+    private async loadCdsAndConvertToJSON(
+        path: string,
+        sort: boolean
+    ): Promise<unknown> {
         const csn = await cds.load(path);
-        return JSON.parse(cds.compile.to.json(csn));
+
+        let result: ICsn = JSON.parse(cds.compile.to.json(csn));
+
+        if (sort) {
+            result.definitions = Object.fromEntries(
+                Object.entries(result.definitions).sort((a, b) =>
+                    String(a[0]).localeCompare(b[0])
+                )
+            );
+        }
+
+        return result;
     }
 
     /**

--- a/src/program.ts
+++ b/src/program.ts
@@ -37,14 +37,6 @@ export class Program {
             fs.writeFileSync(options.output + ".json", JSON.stringify(jsonObj));
         }
 
-        // if (options.sort && typeof jsonObj === "unknow") {
-        //     jsonObj.definitions = Object.fromEntries(
-        //         Object.entries(jsonObj.definitions).sort((a, b) =>
-        //             String(a[0]).localeCompare(b[0])
-        //         )
-        //     );
-        // }
-
         // Parse compile CDS.
         const parsed = new CDSParser().parse(jsonObj as ICsn);
 

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -161,4 +161,5 @@ export interface IOptions {
     debug: boolean;
     version: string;
     format: boolean;
+    sort: boolean;
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
     "compilerOptions": {
         "target": "es2015",
         "module": "commonjs",
-        "lib": ["es6", "es2015", "es2016", "dom"],
+        "lib": ["es6", "es2015", "es2016", "es2020", "dom"],
         "rootDir": "./",
         "downlevelIteration": true,
         "strict": true,


### PR DESCRIPTION
Hello,

It's me again :)

Also, we have added to code a new option: sort. This new option it's to sort contract result (Services, Entities...).

For ejemple:

![image](https://user-images.githubusercontent.com/45922686/160896285-5cf4b628-9003-430d-9739-10505fe6532d.png)

![image](https://user-images.githubusercontent.com/45922686/160895749-ad60ec95-e330-40b1-9df6-3b02e2765c79.png)

And the change result would be:

![image](https://user-images.githubusercontent.com/45922686/160896190-ccbabbac-5a5e-40d6-9ac4-154634be03d7.png)

![image](https://user-images.githubusercontent.com/45922686/160896084-8dc7d59f-2bcf-41de-9658-4fdba45e30b8.png)

As you will be able to see, everything it's sorted, but compositions, that still's right after it's main enitty.


If needed, make the corrections you consider.

Thanks in advandce! And sorry for so much text :)

Best regards,

Kiko
