### PR TITLE
Add hana.tinyint type mapping to number.

### DIFF
--- a/src/types/base.type.ts
+++ b/src/types/base.type.ts
@@ -150,7 +150,8 @@ export abstract class BaseType<O = unknown> {
     ): morph.PropertySignatureStructure {
         let fieldName = name;
         if (fieldName.includes("/")) fieldName = `"${fieldName}"`;
-        if (element.canBeNull || element.type === Type.Association) fieldName = `${fieldName}?`;
+        if (element.canBeNull || element.type === Type.Association)
+            fieldName = `${fieldName}?`;
 
         let fieldType = "unknown";
         if (element.enum) {
@@ -160,7 +161,6 @@ export abstract class BaseType<O = unknown> {
         } else {
             fieldType = this.cdsElementToType(element, types, prefix);
         }
-
 
         return {
             kind: morph.StructureKind.PropertySignature,
@@ -389,6 +389,10 @@ export abstract class BaseType<O = unknown> {
 
             case Type.LargeBinary:
                 result = "Buffer";
+                break;
+
+            case Type.HanaTinyint:
+                result = "number";
                 break;
         }
 

--- a/src/utils/cds.types.ts
+++ b/src/utils/cds.types.ts
@@ -24,6 +24,7 @@ export enum Type {
     LargeString = "cds.LargeString",
     LargeBinary = "cds.LargeBinary",
     User = "User",
+    HanaTinyint = "cds.hana.TINYINT",
 }
 
 export enum Kind {

--- a/test/srv/service.cds
+++ b/test/srv/service.cds
@@ -13,8 +13,9 @@ service CatalogService @(path : '/browse') {
     @readonly
     entity Books            as
         select from my.Books {
-            * ,
-            author.name as author
+            *,
+            author.name as author,
+            virtual 1   as isStockVisible : hana.TINYINT
         }
         excluding {
             createdBy,
@@ -22,15 +23,15 @@ service CatalogService @(path : '/browse') {
         }
 
         actions {
-            action addRating(stars :         Integer);
+            action   addRating(stars : Integer);
             function getViewsCount() returns Integer;
         }
 
-    function getBooks(author : my.Authors:ID) returns array of Books;
-    action unboudAction(simpleParameter : String, arrayParameter : array of arrayParameterType, typedParameter : typedParameterType) returns ActionReturnType;
+    function getBooks(author : my.Authors:ID)                                                                                          returns array of Books;
+    action   unboudAction(simpleParameter : String, arrayParameter : array of arrayParameterType, typedParameter : typedParameterType) returns ActionReturnType;
 
     @requires_ : 'authenticated-user'
-    action submitOrder(book : Books:ID, amount : Integer);
+    action   submitOrder(book : Books:ID, amount : Integer);
 
 
     type arrayParameterType : {


### PR DESCRIPTION
Hello,

In our project, we use type hana.tinyint, to create variables to be use together with annotation @Common.FieldControl. This type was mapped into "unknown" by the package. So we changed it, and now it is map to "number".

For instance, we add "isStockVisible" variable of type hana.tinyint into Books:

![image](https://user-images.githubusercontent.com/45922686/181393004-e71ba6c3-f418-4827-96d9-5110737e912e.png)


As a result, initially we got this on the contract:

![image](https://user-images.githubusercontent.com/45922686/181393020-e877f37f-86b0-40fa-91cb-fb4fb13abd04.png)


And, aftter adding the new mapping, the result we get is:

![image](https://user-images.githubusercontent.com/45922686/181393046-59a5bb9a-677e-47af-9fbe-ed48bd748ed9.png)


I hope it is usefull. If needed, make the corrections you consider.

Thanks in advandce!

Best regards,

Kiko