### PR TITLE
feat: prefer locally installed @sap/cds package

### DIFF
--- a/src/program.ts
+++ b/src/program.ts
@@ -1,5 +1,4 @@
 import _ from "lodash";
-import cds from "@sap/cds";
 import * as fs from "fs-extra";
 import * as morph from "ts-morph";
 import * as path from "path";
@@ -11,6 +10,10 @@ import { Namespace } from "./types/namespace";
 import { Formatter } from "./formatter/formatter";
 import { NoopFormatter } from "./formatter/noop.formatter";
 import { PrettierFormatter } from "./formatter/prettier.formatter";
+
+// load @sap/cds with preference to a locally installed package in the current project
+const localCdsPackage = path.join(process.cwd(), "node_modules", "@sap/cds");
+const cds = require(localCdsPackage) || require("@sap/cds");
 
 /**
  * Main porgram class.


### PR DESCRIPTION
Hello,

in our project we are already using the module `@sap/cds` in version 6.2.2 which comes with new reuse types (e.g. sap.common.Locale). Because of this the type generation is currently not working as `cds2types` is working with an older version.

In this pull request I solved the issue by looking first for a locally installed version of the `@sap/cds` package and using that one for `CSN` file generation.

This would also have the advantage that the creation of `CSN` file would always be done with the same version with which the `cds` schema is generated in the specific CAP project.

Regards,
Ludwig