### PR TITLE
feat(parser): Generate nullable fields, rename `canBeNull` to `optional`

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ entity Books : managed {
     key ID              : Integer;
         title           : localized String(111);
         descr           : localized String(1111);
-        longdesc        : localized String(1111111);
+        longdesc        : localized String(1111111) null;
         author          : Association to Authors;
         genre           : Association to Genres;
         stock           : Integer;
@@ -183,7 +183,7 @@ export interface IBooks {
     ID: number;
     title: string;
     descr: string;
-    longdesc: string;
+    longdesc: string | null;
     author?: IAuthors;
     author_ID?: number;
     genre?: IGenres;

--- a/src/cds.parser.ts
+++ b/src/cds.parser.ts
@@ -284,7 +284,10 @@ export class CDSParser {
                         ? element.items.type
                         : "";
 
-                    const canBeNull =
+                    // By default, elements are always not nullable.
+                    const canBeNull = element.notNull === false;
+
+                    const optional =
                         element["@Core.Computed"] ||
                         element["@Core.Immutable"] ||
                         element.virtual ||
@@ -307,6 +310,7 @@ export class CDSParser {
                     result.set(elementName, {
                         type: type,
                         canBeNull: canBeNull,
+                        optional: optional,
                         cardinality: cardinality,
                         target: element.target,
                         enum: _enum.size <= 0 ? undefined : _enum,

--- a/src/types/action.func.ts
+++ b/src/types/action.func.ts
@@ -200,6 +200,7 @@ export class ActionFunction extends BaseType<IActionFunctionDeclarationStructure
                         {
                             type: value.type as string,
                             canBeNull: false,
+                            optional: false,
                             cardinality: (value as ITypeAliasDefinition).isArray
                                 ? { max: Cardinality.many }
                                 : { max: Cardinality.one },

--- a/src/types/base.type.ts
+++ b/src/types/base.type.ts
@@ -158,7 +158,7 @@ export abstract class BaseType<O = unknown> {
     ): morph.PropertySignatureStructure {
         let fieldName = name;
         if (fieldName.includes("/")) fieldName = `"${fieldName}"`;
-        if (element.canBeNull || element.type === Type.Association || name === "texts")
+        if (element.optional || element.type === Type.Association || name === "texts")
             fieldName = `${fieldName}?`;
 
         let fieldType = "unknown";
@@ -168,6 +168,10 @@ export abstract class BaseType<O = unknown> {
                 this.sanitizeName(name);
         } else {
             fieldType = this.cdsElementToType(element, types, interfaceName, prefix);
+        }
+
+        if (element.canBeNull) {
+            fieldType += " | null";
         }
 
         return {

--- a/src/utils/cds.types.ts
+++ b/src/utils/cds.types.ts
@@ -72,6 +72,7 @@ export interface ICsnElement {
     target?: string;
     keys?: ICsnKeys[];
     cardinality?: ICsnCardinality;
+    notNull?: boolean;
     virtual?: boolean;
     default?: ICsnValue;
     enum?: IEnum;

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -26,6 +26,7 @@ export interface IEnum {
 export interface IElement {
     type: Type | string;
     canBeNull: boolean;
+    optional: boolean;
     cardinality?: { max: Cardinality };
     target?: string;
     enum?: Map<string, ICsnValue>;

--- a/test/service.test.ts
+++ b/test/service.test.ts
@@ -20,6 +20,7 @@ const serviceEntity: IServiceEntity = {
         },
     ],
     arraySimple: [""],
+    nullable: null
 };
 
 const arrayUsingEntity: IArrayUsingEntity = {

--- a/test/srv/service.cds
+++ b/test/srv/service.cds
@@ -6,6 +6,7 @@ service CatalogService @(path : '/browse') {
         key id           : UUID;
             arrayComplex : array of arrayParameterType;
             arraySimple  : array of String;
+            nullable     : String null;
     }
 
     entity ArrayUsingEntity as projection on my.ArrayUsingEntity;


### PR DESCRIPTION
This is different from optional fields (`field?: type`) in that we can use `null` as a value instead of writing the property altogether.

For example:
```ts
interface MyType {
  optionalField?: boolean;
  nullableField: boolean | null;
  optionalAndNullableField?: boolean | null;
}

const obj: MyType = {
  // no optionalField here is fine, TypeScript won't complain

  nullableField: null, // this is fine as well, TypeScript won't complain

  optionalAndNullableField: null // this is fine as well, but we could also not include this field and TypeScript wouldn't complain either
}
```

Renamed old `canBeNull` to `optional` to be able to reuse `canBeNull` for the new functionality.

I didn't know what to do on action.func.ts, so I just defaulted `canBeNull` to false.